### PR TITLE
Fixing spelling of v after j/q/x.

### DIFF
--- a/baxter/mc2pinyin.py
+++ b/baxter/mc2pinyin.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-"""Converts Baxter's notation to predicted Pinyin."""
+"""Converts Baxter's notation to predicted Pinyin.
+
+python -m baxter.mc2pinyin -o /tmp/mismatches.csv
+"""
 
 import argparse
 import os.path

--- a/baxter/steps.py
+++ b/baxter/steps.py
@@ -181,6 +181,8 @@ def _substituted_final_r2(init_r2, final_r2):
       final_r2 = 'w' + final_r2[1:]
     elif final_r2.startswith('v'):
       final_r2 = 'yu' + final_r2[1:]
+  if init_r2 in ('j', 'q', 'x') and final_r2.startswith('v'):
+    final_r2 = 'u' + final_r2[1:]
   return final_r2
 
 def expected_msm_syllable(syl):

--- a/baxter/steps_test.py
+++ b/baxter/steps_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Tests for steps module."""
 
 import unittest
@@ -12,3 +13,8 @@ class StepsTest(unittest.TestCase):
     """Example given by Brian along w/initial steps."""
     self.assertEqual(steps.expected_pinyin(mc.MiddleChineseSyllable('trhik')),
                      'chi4')
+
+  def test_v_spelling(self):
+    """'v' (i.e., 'ü') is spelled 'u' after 'j', 'q', and 'x'."""
+    self.assertEqual(steps.expected_pinyin(mc.MiddleChineseSyllable('khjuX')),
+                     'qu3')


### PR DESCRIPTION
- Improves match rate from ~20% to ~21%.
- Added a test case.
- Also, the import logic in python is a bit wonky. In making pylint
  happy, I broke the obvious way to invoke mc2pinyin, so I've added
  a comment on how to invoke it.