### PR TITLE
Fixing issues with tones and (u)o's.

### DIFF
--- a/baxter/steps.py
+++ b/baxter/steps.py
@@ -97,13 +97,15 @@ def _simplify_final_r1(final_r1, bax):
 def _tone_r2(tone_r1, init_r1):
   """Get second round tone."""
   tone_r2 = tone_r1
-  if tone_r1 == '1' and init_r1[0] not in 'vV':
+  if tone_r1 == '1' and init_r1[0] in 'vVrl':
     tone_r2 = '2'
   elif tone_r1 == '2':
     if init_r1[0] == 'V':
       tone_r2 = '4'
     else:
       tone_r2 = '3'
+  elif tone_r1 == '3':
+    tone_r2 = '4'
   elif tone_r1 == '4' and init_r1[0] == 'V':
     tone_r2 = '2'
   return tone_r2
@@ -185,6 +187,8 @@ def _substituted_final_r2(init_r2, final_r2):
       final_r2 = 'yu' + final_r2[1:]
   if init_r2 in ('j', 'q', 'x', 'r') and final_r2.startswith('v'):
     final_r2 = 'u' + final_r2[1:]
+  if init_r2 not in ('b', 'p', 'm', 'f', 'w') and final_r2 == 'o':
+    final_r2 = 'uo'
   return final_r2
 
 def expected_msm_syllable(syl):

--- a/baxter/steps_test.py
+++ b/baxter/steps_test.py
@@ -40,3 +40,18 @@ class StepsTest(unittest.TestCase):
     self.expect_pinyin('nywen', 'ruan2')
     self.expect_pinyin('nywin', 'run2')
 
+  def test_tones(self):
+    """Test that tones work."""
+    self.expect_pinyin("'oj", 'ai1')
+    self.expect_pinyin('ngaw', 'ao2')
+    self.expect_pinyin('baeH', 'ba4')
+    self.expect_pinyin('nyo', 'ru2')
+    self.expect_pinyin('la', 'luo2')
+
+  def test_uo_spelling(self):
+    """Test that (u)o is spelled right."""
+    self.expect_pinyin('tha', 'tuo1')
+    self.expect_pinyin('tsha', 'cuo1')
+    self.expect_pinyin('dak', 'duo2')
+    self.expect_pinyin('hwat', 'huo2')
+


### PR DESCRIPTION
- The logic for voicing (to determine yinping vs yangping) was
  backwards.
- l's and r's weren't being counted as voiced, so fixing the
  previous thing broke ping tone r- and l- words.
- The only good test case I could find for ping tone l- words
  also had an issue where -uo was only ever spelled as -o.
- Qu tones were always being given as 3 instead of 4.